### PR TITLE
Make switching projects in RStudio work

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,7 @@ Note that [RStudio Server Pro](https://www.rstudio.com/products/rstudio-server-p
 ## Installation
 
 ### Pre-reqs
-#### Install [nbserverproxy](https://github.com/jupyterhub/nbserverproxy)
-```
-pip install git+https://github.com/jupyterhub/nbserverproxy
-```
 
-Either install the nbserverproxy extensions for the user:
-```
-jupyter serverextension enable --py nbserverproxy
-```
-
-Or install the nbserverproxy extensions for all users on the system:
-```
-jupyter serverextension enable --py --sys-prefix nbserverproxy
-```
 #### Install rstudio
 Use conda `conda install rstudio` or [download](https://www.rstudio.com/products/rstudio/download-server/) the corresponding package for your platform 
 

--- a/nbrsessionproxy/static/tree.js
+++ b/nbrsessionproxy/static/tree.js
@@ -29,7 +29,7 @@ define(function(require) {
         var rsession_link = $('<a>')
             .attr('role', 'menuitem')
             .attr('tabindex', '-1')
-            .attr('href', base_url + 'rstudio')
+            .attr('href', base_url + 'rstudio/')
             .attr('target', '_blank')
             .text('RStudio Session');
 


### PR DESCRIPTION
This PR contains a number of fundamental imrovements!

- We supervise the rsession process, restarting it if it stops with a non zero exit code.
  This is just good practice anyway, and it also allows 'projects' functionality in rstudio to work
- We just proxy everything via '/rstudio/' rather than redirect people to the /proxy/<port>/ URL.

  This provides a number of benefits:
    - Users never see a 'Connection Refused' error, since we check to
      make sure the process is up before forwarding them through
    - Consistent URL rather than exposing internal detail of what port
      is being used!
    - Much better experience when switching projects - you get a small
      message that says 'switching projects', then a spinner then it
      exists!
    - Make sure that port is shared across requests, rather than a
      new one being allocated per request! This worked before by
      accident :)
    - Use trailing slash when accessing rstudio (so rstudio/ than
      rstudio), to make relative URLs used by rstudio work properly.
      This too worked before by accident
    - Don't make a HTTP request to check before each GET. This is
      not necessary, since we know the process is up (since we watch
      for SIGCHLD and delete the proc key if it is dead)
