### PR TITLE
Cleanup code + make Shiny work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # nbrsessionproxy
 
-**nbrsessionproxy** provides Jupyter server and notebook extensions to proxy an RStudio rsession.
+**nbrsessionproxy** provides Jupyter server and notebook extensions to proxy RStudio.
 
 ![Screenshot](screenshot.png)
 
-If you have a JupyterHub deployment, nbrsessionproxy can take advantage of JupyterHub's existing authenticator and spawner to launch RStudio in users' Jupyter environments. You can also run this from within Jupyter. Requires [nbserverproxy](https://github.com/jupyterhub/nbserverproxy).
-
+If you have a JupyterHub deployment, nbrsessionproxy can take advantage of JupyterHub's existing authenticator and spawner to launch RStudio in users' Jupyter environments. You can also run this from within Jupyter.
 Note that [RStudio Server Pro](https://www.rstudio.com/products/rstudio-server-pro/architecture) has more featureful authentication and spawning than the standard version, in the event that you do not want to use Jupyter's.
 
 ## Installation
@@ -14,6 +13,8 @@ Note that [RStudio Server Pro](https://www.rstudio.com/products/rstudio-server-p
 
 #### Install rstudio
 Use conda `conda install rstudio` or [download](https://www.rstudio.com/products/rstudio/download-server/) the corresponding package for your platform 
+
+Note that rstudio server is needed to work with this extension.
 
 ### Install nbrsessionproxy 
 Install the library:

--- a/nbrsessionproxy/handlers.py
+++ b/nbrsessionproxy/handlers.py
@@ -1,40 +1,14 @@
 import os
 import getpass
-import socket
-import subprocess
 from urllib.parse import urlunparse, urlparse
 
-from tornado import web, gen, httpclient, process, ioloop
+from tornado import web
 
 from notebook.utils import url_path_join as ujoin
 from notebook.base.handlers import IPythonHandler
 
 from nbserverproxy.handlers import SuperviseAndProxyHandler
 
-
-def detectR():
-    '''Detect R's version, R_HOME, and various other directories that rsession
-       requires.
-
-       Via rstudio's src/cpp/core/r_util/REnvironmentPosix.cpp'''
-
-    cmd = ['R', '--slave', '--vanilla', '-e',
-             'cat(paste(R.home("home"),R.home("share"),R.home("include"),R.home("doc"),getRversion(),sep=":"))']
-
-    p = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    if p.returncode != 0:
-        raise Exception('Error detecting R')
-    R_HOME, R_SHARE_DIR, R_INCLUDE_DIR, R_DOC_DIR, version = \
-        p.stdout.decode().split(':')
-
-    return {
-        'R_DOC_DIR': R_DOC_DIR,
-        'R_HOME': R_HOME,
-        'R_INCLUDE_DIR': R_INCLUDE_DIR,
-        'R_SHARE_DIR': R_SHARE_DIR,
-        'RSTUDIO_DEFAULT_R_VERSION_HOME': R_HOME,
-        'RSTUDIO_DEFAULT_R_VERSION': version,
-    }
 
 class AddSlashHandler(IPythonHandler):
     """Handler for adding trailing slash to URLs that need them"""
@@ -51,16 +25,9 @@ class RSessionProxyHandler(SuperviseAndProxyHandler):
     name = 'rsession'
 
     def get_env(self):
-        env = {
-            'RSTUDIO_LIMIT_RPC_CLIENT_UID':'998',
-            'RSTUDIO_MINIMUM_USER_ID':'500',
-        }
-
-        try:
-            r_vars = detectR()
-            env.update(r_vars)
-        except:
-            raise web.HTTPError(reason='could not detect R', status_code=500)
+        env = {}
+        if 'USER' not in os.environ:
+            env['USER'] = getpass.getuser()
 
         return env
 
@@ -68,7 +35,6 @@ class RSessionProxyHandler(SuperviseAndProxyHandler):
         # rsession command. Augmented with user-identity and www-port.
         return [
             'rserver',
-            '--server-user=' + getpass.getuser(),
             '--www-port=' + str(self.port)
         ]
 
@@ -77,5 +43,3 @@ def setup_handlers(web_app):
         (ujoin(web_app.settings['base_url'], 'rstudio/(.*)'), RSessionProxyHandler, dict(state={})),
         (ujoin(web_app.settings['base_url'], 'rstudio'), AddSlashHandler)
     ])
-
-# vim: set et ts=4 sw=4:

--- a/nbrsessionproxy/handlers.py
+++ b/nbrsessionproxy/handlers.py
@@ -67,12 +67,8 @@ class RSessionProxyHandler(SuperviseAndProxyHandler):
     def get_cmd(self):
         # rsession command. Augmented with user-identity and www-port.
         return [
-            'rsession',
-            '--standalone=1',
-            '--program-mode=server',
-            '--log-stderr=1',
-            '--session-timeout-minutes=0',
-            '--user-identity=' + getpass.getuser(),
+            'rserver',
+            '--server-user=' + getpass.getuser(),
             '--www-port=' + str(self.port)
         ]
 

--- a/nbrsessionproxy/handlers.py
+++ b/nbrsessionproxy/handlers.py
@@ -26,7 +26,10 @@ class RSessionProxyHandler(SuperviseAndProxyHandler):
 
     def get_env(self):
         env = {}
-        if 'USER' not in os.environ:
+
+        # rserver needs USER to be set to something sensible,
+        # otherwise it'll throw up an authentication page
+        if not os.environ.get('USER', ''):
             env['USER'] = getpass.getuser()
 
         return env


### PR DESCRIPTION
- Switch to using rserver instead of rsession (thanks to @cmd-ntrf for the idea / #7)
  This gets shiny working as well as providing more robust process supervision
- Set USER regardless of it being present in current env or not. rserver needs this
  to not throw up a screen around authentication
- rserver does a lot of the environment introspection we were doing, so remove that.