### PR TITLE
Add shiny proxy.

### DIFF
--- a/nbrsessionproxy/handlers.py
+++ b/nbrsessionproxy/handlers.py
@@ -1,3 +1,4 @@
+# vim: set et sw=4 ts=4:
 import os
 import getpass
 import pwd
@@ -48,7 +49,7 @@ class ShinyProxyHandler(SuperviseAndProxyHandler):
     '''Manage a Shiny instance.'''
 
     name = 'shiny'
-	conf_tmpl = """run_as {user};
+    conf_tmpl = """run_as {user};
 server {{
   listen {port};
   location / {{
@@ -59,21 +60,21 @@ server {{
 }}
 """
 
-	def write_conf(self, user, port, site_dir):
-		'''Create a configuration file and return its name.'''
-		conf = self.conf_tmpl.format(user=user, port=port, site_dir=site_dir)
-		f = tempfile.NamedTemporaryFile(mode='w', delete=False)
-		f.write(conf)
-		f.close()
-		return f.name
+    def write_conf(self, user, port, site_dir):
+        '''Create a configuration file and return its name.'''
+        conf = self.conf_tmpl.format(user=user, port=port, site_dir=site_dir)
+        f = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        f.write(conf)
+        f.close()
+        return f.name
 
     def get_env(self):
         return {}
 
     def get_cmd(self):
-		user = getpass.getuser()
-		site_dir = pwd.getpwnam(user).pw_dir
-		filename = self.write_conf(user, self.port, site_dir)
+        user = getpass.getuser()
+        site_dir = pwd.getpwnam(user).pw_dir
+        filename = self.write_conf(user, self.port, site_dir)
 
         # shiny command.
         return [ 'shiny-server', filename ] 

--- a/nbrsessionproxy/handlers.py
+++ b/nbrsessionproxy/handlers.py
@@ -41,8 +41,20 @@ class RSessionProxyHandler(SuperviseAndProxyHandler):
             '--www-port=' + str(self.port)
         ]
 
+class ShinyProxyHandler(SuperviseAndProxyHandler):
+    '''Manage a Shiny instance.'''
+
+    name = 'shiny'
+    port = '3838'
+
+    def get_cmd(self):
+        # rsession command. Augmented with user-identity and www-port.
+        return [ 'shiny-server' ] 
+
 def setup_handlers(web_app):
     web_app.add_handlers('.*', [
         (ujoin(web_app.settings['base_url'], 'rstudio/(.*)'), RSessionProxyHandler, dict(state={})),
-        (ujoin(web_app.settings['base_url'], 'rstudio'), AddSlashHandler)
+        (ujoin(web_app.settings['base_url'], 'shiny/(.*)'),   ShinyProxyHandler, dict(state={})),
+        (ujoin(web_app.settings['base_url'], 'rstudio'), AddSlashHandler),
+        (ujoin(web_app.settings['base_url'], 'shiny'),   AddSlashHandler)
     ])

--- a/nbrsessionproxy/handlers.py
+++ b/nbrsessionproxy/handlers.py
@@ -47,6 +47,9 @@ class ShinyProxyHandler(SuperviseAndProxyHandler):
     name = 'shiny'
     port = '3838'
 
+    def get_env(self):
+        return {}
+
     def get_cmd(self):
         # rsession command. Augmented with user-identity and www-port.
         return [ 'shiny-server' ] 


### PR DESCRIPTION
Things to look at beyond this minimum viable product: this PR assumes that shiny is running on 3838 whereas we randomly choose rstudio's port. It must be kept it sync with the port defined in a shiny-server.conf. This PR doesn't specify the location of the config file on invocation so shiny will look for it in /etc/shiny-server/.