### PR TITLE
Add missing psmisc and libssl dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update && \
 		libapparmor1 \
 		libedit2 \
 		lsb-release \
+		psmisc \
+		libssl1.0.0 \
 		;
 
 # You can use rsession from rstudio's desktop package as well.


### PR DESCRIPTION
Currenly, `docker build` fails:

```
...
Step 6/17 : RUN dpkg -i ${RSTUDIO_PKG}
 ---> Running in f3db2d264a84
Selecting previously unselected package rstudio-server.
(Reading database ... 119278 files and directories currently installed.)
Preparing to unpack rstudio-server-1.0.136-amd64.deb ...
Unpacking rstudio-server (1.0.136) ...
dpkg: dependency problems prevent configuration of rstudio-server:
 rstudio-server depends on psmisc; however:
  Package psmisc is not installed.
 rstudio-server depends on libssl1.0.0; however:
  Package libssl1.0.0 is not installed.

dpkg: error processing package rstudio-server (--install):
 dependency problems - leaving unconfigured
Errors were encountered while processing:
 rstudio-server
The command '/bin/sh -c dpkg -i ${RSTUDIO_PKG}' returned a non-zero code: 1
```
This pull request adds necessary dependencies for a successful build.